### PR TITLE
Dev/cross origin

### DIFF
--- a/src/main/java/com/health/sugar/lf10sugarhealth/WebConfig.java
+++ b/src/main/java/com/health/sugar/lf10sugarhealth/WebConfig.java
@@ -1,0 +1,16 @@
+package com.health.sugar.lf10sugarhealth;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**");
+    }
+}

--- a/src/main/java/com/health/sugar/lf10sugarhealth/controller/MemberController.java
+++ b/src/main/java/com/health/sugar/lf10sugarhealth/controller/MemberController.java
@@ -124,7 +124,7 @@ public class MemberController {
 
         } catch (DataIntegrityViolationException dve)
         {
-            logger.error("Ein Nutzer mit diesem Google-Konto existiert bereits.");
+            logger.error("Ein Nutzer mit diesem Login-Konto existiert bereits.");
             return new ResponseEntity<>(null, HttpStatus.CONFLICT);
         }
         catch (Exception e) {


### PR DESCRIPTION
Blöden Kommentar wirklich jetzt angepasst (unsauber gearbeitet, aber naja)

Neue Klasse "WebConfig" erstellt, um CrossOrigins global zu erlauben (kann später noch angepasst werden, um nur bestimmte Quellen zu erlauben), damit Frontend Requests schicken kann